### PR TITLE
Create header.stamp from timestamp instead of from tamebase

### DIFF
--- a/src/lio/ScanRegistration.cpp
+++ b/src/lio/ScanRegistration.cpp
@@ -31,7 +31,8 @@ void lidarCallBackHorizon(const livox_ros_driver::CustomMsgConstPtr &msg) {
   sensor_msgs::PointCloud2 laserCloudMsg;
   pcl::toROSMsg(*laserCloud, laserCloudMsg);
   laserCloudMsg.header = msg->header;
-  laserCloudMsg.header.stamp.fromNSec(msg->timebase+msg->points.back().offset_time);
+  ros::Duration duration(0, msg->points.back().offset_time);
+  laserCloudMsg.header.stamp = laserCloudMsg.header.stamp + duration;
   pubFullLaserCloud.publish(laserCloudMsg);
 
 }


### PR DESCRIPTION
__Summary__
 /livox_full_cloud topic timestamp created from timestamp.

* Generate `header.stamp` from `timestamp` instead of from `timebase` to match the standard time format of ROS.